### PR TITLE
fix: incorrect data type when extracting data using jmespath

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## v0.6.2 (2022-02-20)
+- change: json unmarshal to json.Number when parsing data
+- fix: incorrect data type when extracting data using jmespath
+
 ## v0.6.1 (2022-02-17)
 
 - fix: set request Content-Type for posting json only when not specified

--- a/examples/demo.json
+++ b/examples/demo.json
@@ -119,8 +119,12 @@
                 },
                 "body": {
                     "foo1": "$varFoo1",
-                    "foo2": "${max($a, $b)}"
+                    "foo2": "${max($a, $b)}",
+                    "time": "${get_timestamp()}"
                 }
+            },
+            "extract": {
+                "varTime": "body.form.time"
             },
             "validate": [
                 {
@@ -140,6 +144,24 @@
                     "assert": "equals",
                     "expect": "12.3",
                     "msg": "check args foo2"
+                }
+            ]
+        },
+        {
+            "name": "final check",
+            "request": {
+                "method": "GET",
+                "url": "/get",
+                "params": {
+                    "time": "$varTime"
+                }
+            },
+            "validate": [
+                {
+                    "check": "body.args.time",
+                    "assert": "length_equals",
+                    "expect": 13,
+                    "msg": "check extracted var timestamp"
                 }
             ]
         }

--- a/examples/demo.json
+++ b/examples/demo.json
@@ -148,7 +148,7 @@
             ]
         },
         {
-            "name": "final check",
+            "name": "get with timestamp",
             "request": {
                 "method": "GET",
                 "url": "/get",

--- a/examples/demo.yaml
+++ b/examples/demo.yaml
@@ -80,6 +80,9 @@ teststeps:
         body:
             foo1: $varFoo1
             foo2: ${max($a, $b)}
+            time: ${get_timestamp()}
+      extract:
+        varTime: body.form.time
       validate:
         - check: status_code
           assert: equals
@@ -93,3 +96,14 @@ teststeps:
           assert: equals
           expect: "12.3"
           msg: check args foo2
+    - name: final check
+      request:
+        method: GET
+        url: /get
+        params:
+            time: $varTime
+      validate:
+        - check: body.args.time
+          assert: length_equals
+          expect: 13
+          msg: check extracted var timestamp

--- a/examples/demo.yaml
+++ b/examples/demo.yaml
@@ -96,7 +96,7 @@ teststeps:
           assert: equals
           expect: "12.3"
           msg: check args foo2
-    - name: final check
+    - name: get with timestamp
       request:
         method: GET
         url: /get

--- a/internal/scaffold/demo.go
+++ b/internal/scaffold/demo.go
@@ -48,11 +48,18 @@ var demoTestCase = &hrp.TestCase{
 			WithBody(map[string]interface{}{
 				"foo1": "$varFoo1",       // reference former extracted variable
 				"foo2": "${max($a, $b)}", // 12.3; step level variables are independent, variable b is 3.45 here
+				"time": "${get_timestamp()}",
 			}).
+			Extract().
+			WithJmesPath("body.form.time", "varTime").
 			Validate().
 			AssertEqual("status_code", 200, "check status code").
 			AssertLengthEqual("body.form.foo1", 5, "check args foo1").
 			AssertEqual("body.form.foo2", "12.3", "check args foo2"), // form data will be converted to string
+		hrp.NewStep("get with timestamp").
+			GET("/get").WithParams(map[string]interface{}{"time": "$varTime"}).
+			Validate().
+			AssertLengthEqual("body.args.time", 13, "check extracted var timestamp"),
 	},
 }
 

--- a/parser.go
+++ b/parser.go
@@ -69,8 +69,7 @@ func (p *parser) parseData(raw interface{}, variablesMapping map[string]interfac
 	case reflect.String:
 		// json.Number
 		if rawValue, ok := raw.(json.Number); ok {
-			// use the same rule as json.Unmarshal (float64, for JSON numbers)
-			return rawValue.Float64()
+			return parseJSONNumber(rawValue)
 		}
 		// other string
 		value := rawValue.String()
@@ -106,6 +105,16 @@ func (p *parser) parseData(raw interface{}, variablesMapping map[string]interfac
 	default:
 		// other types, e.g. nil, int, float, bool
 		return raw, nil
+	}
+}
+
+func parseJSONNumber(raw json.Number) (interface{}, error) {
+	if strings.Contains(raw.String(), ".") {
+		// float64
+		return raw.Float64()
+	} else {
+		// int64
+		return raw.Int64()
 	}
 }
 


### PR DESCRIPTION
## Main Changes
- change: json unmarshal to json.Number when parsing data
- fix: incorrect data type when extracting data using jmespath
- add: test timestamp extraction unittest