### PR TITLE
feat: support statistics summary for load testing

### DIFF
--- a/cli/hrp/cmd/boom.go
+++ b/cli/hrp/cmd/boom.go
@@ -43,6 +43,7 @@ var boomCmd = &cobra.Command{
 		hrpBoomer.SetDisableCompression(disableCompression)
 		hrpBoomer.EnableCPUProfile(cpuProfile, cpuProfileDuration)
 		hrpBoomer.EnableMemoryProfile(memoryProfile, memoryProfileDuration)
+		hrpBoomer.EnableGracefulQuit()
 		hrpBoomer.Run(paths...)
 	},
 }

--- a/internal/boomer/boomer.go
+++ b/internal/boomer/boomer.go
@@ -2,6 +2,9 @@ package boomer
 
 import (
 	"math"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -93,6 +96,16 @@ func (b *Boomer) EnableCPUProfile(cpuProfile string, duration time.Duration) {
 func (b *Boomer) EnableMemoryProfile(memoryProfile string, duration time.Duration) {
 	b.memoryProfile = memoryProfile
 	b.memoryProfileDuration = duration
+}
+
+// EnableGracefulQuit catch SIGINT and SIGTERM signals to quit gracefully
+func (b *Boomer) EnableGracefulQuit() {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		<-c
+		b.Quit()
+	}()
 }
 
 // Run accepts a slice of Task and connects to the locust master.


### PR DESCRIPTION
当压测结束时，打印压测结果数据统计，效果如下：
![image](https://user-images.githubusercontent.com/43516634/158603462-a7427c07-2308-4102-beca-5d606a2714ee.png)