### PR TITLE
feat: support think time for load testing #120

### DIFF
--- a/boomer.go
+++ b/boomer.go
@@ -150,6 +150,10 @@ func (b *HRPBoomer) convertBoomerTask(testcase *TestCase, rendezvousList []*Rend
 					}
 				} else if stepData.StepType == stepTypeRendezvous {
 					// rendezvous
+					// TODO: implement rendezvous in boomer
+				} else if stepData.StepType == stepTypeThinkTime {
+					// think time
+					// no record required
 				} else {
 					// request or testcase step
 					b.RecordSuccess(step.Type(), step.Name(), stepData.Elapsed, stepData.ContentSize)

--- a/convert.go
+++ b/convert.go
@@ -156,6 +156,10 @@ func (tc *TCase) ToTestCase() (*TestCase, error) {
 			testCase.TestSteps = append(testCase.TestSteps, &StepTestCaseWithOptionalArgs{
 				step: step,
 			})
+		} else if step.ThinkTime != nil {
+			testCase.TestSteps = append(testCase.TestSteps, &StepThinkTime{
+				step: step,
+			})
 		} else if step.Request != nil {
 			testCase.TestSteps = append(testCase.TestSteps, &StepRequestWithOptionalArgs{
 				step: step,

--- a/convert_test.go
+++ b/convert_test.go
@@ -11,6 +11,7 @@ var (
 	demoTestCaseYAMLPath    TestCasePath = "examples/demo.yaml"
 	demoRefAPIYAMLPath      TestCasePath = "examples/ref_api_test.yaml"
 	demoRefTestCaseJSONPath TestCasePath = "examples/ref_testcase_test.json"
+	demoThinkTimeJsonPath   TestCasePath = "examples/think_time_test.json"
 	demoAPIYAMLPath         APIPath      = "examples/api/put.yml"
 )
 

--- a/examples/think_time_test.json
+++ b/examples/think_time_test.json
@@ -1,0 +1,63 @@
+{
+    "config": {
+        "name": "think time test demo",
+        "variables": {
+            "app_version": "v1",
+            "user_agent": "iOS/10.3"
+        },
+        "base_url": "https://postman-echo.com",
+        "think_time": {
+            "strategy": "random_percentage",
+            "setting": {
+                "min_percentage": 1,
+                "max_percentage": 1.5
+            },
+            "limit": 4
+        },
+        "verify": false
+    },
+    "teststeps": [
+        {
+            "name": "get with params",
+            "request": {
+                "method": "GET",
+                "url": "/get",
+                "headers": {
+                    "User-Agent": "$user_agent,$app_version"
+                }
+            },
+            "validate": [
+                {
+                    "check": "status_code",
+                    "assert": "equals",
+                    "expect": 200,
+                    "msg": "check status code"
+                }
+            ]
+        },
+        {
+            "name": "think time 1",
+            "think_time": {
+                "time": 3
+            }
+        },
+        {
+            "name": "post with params",
+            "request": {
+                "method": "POST",
+                "url": "/post",
+                "headers": {
+                    "User-Agent": "$user_agent,$app_version"
+                }
+            },
+            "validate": [
+                {
+                    "check": "status_code",
+                    "assert": "equals",
+                    "expect": 200,
+                    "msg": "check status code"
+                }
+            ]
+        }
+    ]
+}

--- a/examples/think_time_test.yaml
+++ b/examples/think_time_test.yaml
@@ -1,0 +1,40 @@
+config:
+  name: "think time test demo"
+  variables:
+    app_version: v1
+    user_agent: iOS/10.3
+  base_url: "https://postman-echo.com"
+  think_time:
+    strategy: random_percentage
+    setting:
+      min_percentage: 1.0
+      max_percentage: 1.5
+    limit: 4
+  verify: False
+
+teststeps:
+  - name: get with params
+    request:
+      method: GET
+      url: /get
+      headers:
+        User-Agent: $user_agent,$app_version
+    validate:
+      - check: status_code
+        assert: equals
+        expect: 200
+        msg: check status code
+  - name: think time 1
+    think_time:
+      time: 3
+  - name: post with params
+    request:
+      method: POST
+      url: /post
+      headers:
+        User-Agent: $user_agent,$app_version
+    validate:
+      - check: status_code
+        assert: equals
+        expect: 200
+        msg: check status code

--- a/internal/builtin/function.go
+++ b/internal/builtin/function.go
@@ -5,12 +5,15 @@ import (
 	"crypto/md5"
 	"encoding/csv"
 	"encoding/hex"
+	builtinJSON "encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -219,4 +222,39 @@ func Contains(s []string, e string) bool {
 		}
 	}
 	return false
+}
+
+func GetRandomNumber(min, max int) int {
+	if min > max {
+		return 0
+	}
+	r := rand.Intn(max - min + 1)
+	return min + r
+}
+
+func Interface2Float64(i interface{}) (float64, error) {
+	switch i.(type) {
+	case int:
+		return float64(i.(int)), nil
+	case int32:
+		return float64(i.(int32)), nil
+	case int64:
+		return float64(i.(int64)), nil
+	case float32:
+		return float64(i.(float32)), nil
+	case float64:
+		return i.(float64), nil
+	case string:
+		intVar, err := strconv.Atoi(i.(string))
+		if err != nil {
+			return 0, err
+		}
+		return float64(intVar), err
+	}
+	// json.Number
+	value, ok := i.(builtinJSON.Number)
+	if ok {
+		return value.Float64()
+	}
+	return 0, errors.New("failed to convert interface to float64")
 }

--- a/plugin.go
+++ b/plugin.go
@@ -41,7 +41,6 @@ func initPlugin(path string, logOn bool) (plugin funplugin.IPlugin, err error) {
 	go func() {
 		<-c
 		plugin.Quit()
-		os.Exit(0)
 	}()
 
 	// report event for initializing plugin

--- a/step.go
+++ b/step.go
@@ -40,6 +40,12 @@ func (c *TConfig) WithParameters(parameters map[string]interface{}) *TConfig {
 	return c
 }
 
+// SetThinkTime sets think time config for current testcase.
+func (c *TConfig) SetThinkTime(strategy string, cfg interface{}, limit float64) *TConfig {
+	c.ThinkTime = &ThinkTimeConfig{strategy, cfg, limit}
+	return c
+}
+
 // ExportVars specifies variable names to export for current testcase.
 func (c *TConfig) ExportVars(vars ...string) *TConfig {
 	c.Export = vars
@@ -189,6 +195,16 @@ func (s *StepRequest) EndTransaction(name string) *StepTransaction {
 		Type: transactionEnd,
 	}
 	return &StepTransaction{
+		step: s.step,
+	}
+}
+
+// SetThinkTime sets think time.
+func (s *StepRequest) SetThinkTime(time float64) *StepThinkTime {
+	s.step.ThinkTime = &ThinkTime{
+		Time: time,
+	}
+	return &StepThinkTime{
 		step: s.step,
 	}
 }
@@ -352,6 +368,23 @@ func (s *StepTestCaseWithOptionalArgs) Type() string {
 }
 
 func (s *StepTestCaseWithOptionalArgs) ToStruct() *TStep {
+	return s.step
+}
+
+// StepThinkTime implements IStep interface.
+type StepThinkTime struct {
+	step *TStep
+}
+
+func (s *StepThinkTime) Name() string {
+	return s.step.Name
+}
+
+func (s *StepThinkTime) Type() string {
+	return "thinktime"
+}
+
+func (s *StepThinkTime) ToStruct() *TStep {
 	return s.step
 }
 


### PR DESCRIPTION
支持思考时间，思考时间可选策略：
1. 忽略用例中的思考时间
2. 保持用例中的思考时间
3. 在所设置的思考时间前后百分比的区间内随机取值作为该步的思考时间[min, max]
4. 可设置思考时间的系数，对用例中的思考时间进行放缩

注：如果设置limit参数，且值>0，则将限制以上策略最大思考时间为limit所设置值

用例新增改变：
1. 在用例config中新增字段：
```
"think_time": {
            "strategy": "random_random_percentage",
            "setting": {
                "min_percentage": 1,
                "max_percentage": 1.5
            },  //根据策略限制类型，”random“策略时值为一个长度为2的slice，其余为整形、浮点型、数字字符串皆可，在解析配置时做类型校验转换
            "limit": 4
},
```
2. 测试步中新增步：
```
{
          "name": "",
          "think_time": {
              "name": "think time 1",
              "time": 3
          }
},
```
说明：以上配置将限制思考时间在3-4秒之间